### PR TITLE
Adopt `gha-scala-library-release-workflow`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import ReleaseTransformations.*
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
+
 organization := "com.gu"
 name := "play-json-extensions"
 scalaVersion := "2.13.15"
@@ -25,3 +28,17 @@ scalacOptions ++= Seq(
 Test / testOptions +=
   Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
 parallelExecution := false // <- until TMap thread-safety issues are resolved
+
+// releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  setNextVersion,
+  commitNextVersion
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
Following the configuration steps at https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md

Also:

* https://github.com/guardian/gha-scala-library-release-workflow/issues/20
