### PR TITLE
Make fully cross-versioned release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ organization := "com.gu"
 name := "play-json-extensions"
 scalaVersion := "2.13.15"
 crossScalaVersions := (14 to scalaVersion.value.split('.').last.toInt).map(minor => s"2.13.$minor")
+crossVersion := CrossVersion.full // see https://github.com/scala/bug/issues/12862#issuecomment-2457553135
 description := "Additional type classes for the play-json serialization library"
 
 startYear := Some(2015)


### PR DESCRIPTION
So, instead of releasing `play-json-extensions_2.13`, as I incorrectly did with v1.0.0, we'll release:

* `play-json-extensions_2.13.14`
* `play-json-extensions_2.13.15`

See https://github.com/scala/bug/issues/12862#issuecomment-2457553135
