### PR TITLE
Revert "Make fully cross-versioned release"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Play-Json extensions
 ==========================
 
-[![play-json-extensions_2.13.14 Scala version support](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions_2.13.14/latest.svg)](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions_2.13.14)
-[![play-json-extensions_2.13.15 Scala version support](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions_2.13.15/latest.svg)](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions_2.13.15)
+[![play-json-extensions_2.13 Scala version support](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions/latest.svg)](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions)
 
 This is a minimal fork of [bizzabo/play-json-extensions](https://github.com/bizzabo/play-json-extensions).
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ organization := "com.gu"
 name := "play-json-extensions"
 scalaVersion := "2.13.15"
 crossScalaVersions := (14 to scalaVersion.value.split('.').last.toInt).map(minor => s"2.13.$minor")
-crossVersion := CrossVersion.full // see https://github.com/scala/bug/issues/12862#issuecomment-2457553135
 description := "Additional type classes for the play-json serialization library"
 
 startYear := Some(2015)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 organization := "com.gu"
 name := "play-json-extensions"
 scalaVersion := "2.13.15"
-crossScalaVersions := (14 to scalaVersion.value.split('.').last.toInt).map(minor => s"2.13.$minor")
 description := "Additional type classes for the play-json serialization library"
 
 startYear := Some(2015)
@@ -30,7 +29,6 @@ Test / testOptions +=
 parallelExecution := false // <- until TMap thread-safety issues are resolved
 
 // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
-releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,


### PR DESCRIPTION
Reverts guardian/play-json-extensions#2, and removes cross-compilation across fully-specified Scala versions - it turns out that, thanks to removing the `verifyKnownDirectSubclassesPostTyper()` method (done with 0cd1b51ed7c964706dde5780eeabba7cf34c3499), that `play-json-extensions` is no longer an outlaw, and so it's unnecessary to do that fully-specified cross-compilation.