### PR TITLE
Temporarily remove release version check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ Test / testOptions +=
   Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
 parallelExecution := false // <- until TMap thread-safety issues are resolved
 
-releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
+// releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,


### PR DESCRIPTION
The previous release failed, which may have left some changes in a partial state, such as the tags and GH release. This means that subsequent releases may also fail when trying to read and compare the previous version. This change temporarily removes that check, allowing a fresh release to occur based on `version.sbt`. A new release can then happen, ensuring everything is back in a good state, and then this change can be reverted.
